### PR TITLE
random_numbers: 0.3.2-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3994,8 +3994,8 @@ repositories:
     release:
       tags:
         release: release/melodic/{package}/{version}
-      url: https://github.com/ros-gbp/random_numbers-release.git
-      version: 0.3.2-0
+      url: git@github.com:nuclearsandwich/random_numbers-release
+      version: 0.3.2-3
     source:
       type: git
       url: https://github.com/ros-planning/random_numbers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `random_numbers` to `0.3.2-3`:

- upstream repository: https://github.com/ros-planning/random_numbers
- release repository: git@github.com:nuclearsandwich/random_numbers-release
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.3.2-0`

## random_numbers

```
* Update maintainership. (#11 <https://github.com/ros-planning/random_numbers/issues/11>)
* Contributors: Steven! Ragnarök
```
