### PR TITLE
rcl_interfaces: 0.6.2-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -939,7 +939,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_interfaces` to `0.6.2-0`:

- upstream repository: https://github.com/ros2/rcl_interfaces.git
- release repository: https://github.com/ros2-gbp/rcl_interfaces-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `0.6.1-0`
