### PR TITLE
class_loader: 1.2.0-4 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -204,8 +204,8 @@ repositories:
     release:
       tags:
         release: release/crystal/{package}/{version}
-      url: https://github.com/ros2-gbp/class_loader-release.git
-      version: 1.2.0-0
+      url: git@github.com:nuclearsandwich/class_loader-release
+      version: 1.2.0-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `1.2.0-4`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: git@github.com:nuclearsandwich/class_loader-release
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.2.0-0`

## class_loader

```
* Updated maintainer to Steven! Ragnarok the maintainer (#107 <https://github.com/ros/class_loader/issues/107>)
* Added free impl_ in AbstractMetaObjectBase destructor (#103 <https://github.com/ros/class_loader/issues/103>)
* Overhauled CI.u (#106 <https://github.com/ros/class_loader/issues/106>)
* Fixed spacing to comply with uncrusity 0.67 (#99 <https://github.com/ros/class_loader/issues/99>)
* Updated to use console_bridge_vendor (#98 <https://github.com/ros/class_loader/issues/98>)
* Contributors: Chris Ye, Mikael Arguedas
```
